### PR TITLE
shell-version changed from 3.0.1 to 3.0

### DIFF
--- a/presentationmode@ampad.de/metadata.json
+++ b/presentationmode@ampad.de/metadata.json
@@ -1,5 +1,5 @@
 {
-"shell-version": ["3.0.1"],
+"shell-version": ["3.0"],
 "uuid": "presentationmode@ampad.de",
 "name": "Presentation mode",
 "description": "Add a presentation mode toggle to the power menu.",


### PR DESCRIPTION
Hey,

it's easier with version "3.0" in metadata.json. So you have not to change the version on every gnome-shell release. :)

Btw: The newest version of gnome-shell is 3.0.2. ;)

Greetings
Christoph
