### PR TITLE
Remembering presentation mode state, closes #13

### DIFF
--- a/README
+++ b/README
@@ -21,9 +21,9 @@ mkdir -p ~/.local/share/gnome-shell/extensions/
 
 cp -r presentationmode@ampad.de ~/.local/share/gnome-shell/extensions/
 
-sudo cp org.gnome.shell.extensions.presentationmode.gschema.xml /usr/share/glib-2.0
+sudo cp org.gnome.shell.extensions.presentationmode.gschema.xml /usr/share/glib-2.0/schemas
 
-sudo glib-compile-schemas /usr/share/glib-2.0
+sudo glib-compile-schemas /usr/share/glib-2.0/schemas
 
 
 Copyright (C) 2011, Raphael Kimmig

--- a/README
+++ b/README
@@ -21,6 +21,9 @@ mkdir -p ~/.local/share/gnome-shell/extensions/
 
 cp -r presentationmode@ampad.de ~/.local/share/gnome-shell/extensions/
 
+sudo cp org.gnome.shell.extensions.presentationmode.gschema.xml /usr/share/glib-2.0
+
+sudo glib-compile-schemas /usr/share/glib-2.0
 
 
 Copyright (C) 2011, Raphael Kimmig

--- a/org.gnome.shell.extensions.presentationmode.gschema.xml
+++ b/org.gnome.shell.extensions.presentationmode.gschema.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist>
+  <schema id="org.gnome.shell.extensions.presentationmode" path="/org/gnome/shell/extensions/presentationmode/">
+    <key type="b" name="state">
+      <default>false</default>
+      <summary>State of the presentation mode toggle</summary>
+    </key>
+   </schema>
+</schemalist>

--- a/presentationmode@ampad.de/extension.js
+++ b/presentationmode@ampad.de/extension.js
@@ -2,6 +2,7 @@
 const DBus = imports.dbus;
 const Lang = imports.lang;
 const St = imports.gi.St;
+const Gio = imports.gi.Gio;
 
 const Main = imports.ui.main;
 const PopupMenu = imports.ui.popupMenu;
@@ -11,6 +12,9 @@ const UserMenu = imports.ui.userMenu;
 const Gettext = imports.gettext.domain('gnome-shell-extensions');
 const _ = Gettext.gettext;
 
+const SETTINGS_SCHEMA = 'org.gnome.shell.extensions.presentationmode';
+const SETTINGS_STATE = 'state';
+
 const SessionIface = {
     name: "org.gnome.SessionManager",
     methods: [ 
@@ -19,6 +23,10 @@ const SessionIface = {
     ]
 };
 let SessionProxy = DBus.makeProxyClass(SessionIface);
+let batteryMenu = Main.panel._statusArea.battery;
+
+let Settings = new Gio.Settings({schema: SETTINGS_SCHEMA});
+
 
 // Put your extension initialization code here
 function init(extensionMeta) {
@@ -27,12 +35,30 @@ function init(extensionMeta) {
     imports.gettext.textdomain("gnome-shell-extension-presentationmode");
 }
 
-function enable() {
-    let batteryMenu = Main.panel._statusArea.battery;
+function toggleState() {
+    if(batteryMenu._inhibit) {
+        batteryMenu._sessionProxy.UninhibitRemote(batteryMenu._inhibit);
+        batteryMenu._inhibit = undefined;
+        Settings.set_boolean(SETTINGS_STATE, false);
+        } else {
+            try {
+                batteryMenu._sessionProxy.InhibitRemote("presentor",
+                    0,
+                    "Presentation mode",
+                    9,
+                    Lang.bind(batteryMenu, batteryMenu._onInhibit));
+                Settings.set_boolean(SETTINGS_STATE, true);
+            } catch(e) {
+                //
+            }
+        }
+}
 
+function enable() {
+    let initialState = Settings.get_boolean(SETTINGS_STATE);
     batteryMenu._itemSeparator = new PopupMenu.PopupSeparatorMenuItem();
     batteryMenu.menu.addMenuItem(batteryMenu._itemSeparator);
-    batteryMenu._presentationswitch = new PopupMenu.PopupSwitchMenuItem(_("Presentation mode"), false);
+    batteryMenu._presentationswitch = new PopupMenu.PopupSwitchMenuItem(_("Presentation mode"), initialState);
     batteryMenu.menu.addMenuItem(batteryMenu._presentationswitch);
     batteryMenu._inhibit = undefined;
     batteryMenu._sessionProxy = new SessionProxy(DBus.session, 'org.gnome.SessionManager', '/org/gnome/SessionManager');
@@ -41,27 +67,13 @@ function enable() {
         batteryMenu._inhibit = cookie;
     };
 
-    batteryMenu._presentationswitch.connect('toggled', Lang.bind(batteryMenu, function() {
-        if(batteryMenu._inhibit) {
-            batteryMenu._sessionProxy.UninhibitRemote(batteryMenu._inhibit);
-            batteryMenu._inhibit = undefined;
-            } else {
-                try {
-                    batteryMenu._sessionProxy.InhibitRemote("presentor",
-                        0, 
-                        "Presentation mode",
-                        9,
-                        Lang.bind(batteryMenu, batteryMenu._onInhibit));
-                } catch(e) {
-                    //
-                }
-            }
-    }));
+    batteryMenu._presentationswitch.connect('toggled', toggleState);
+    if(initialState) {
+        toggleState();
+    }
 }
 
 function disable() {
-    let batteryMenu = Main.panel._statusArea.battery;
-
     batteryMenu._presentationswitch.destroy();
     batteryMenu._itemSeparator.destroy();
     if(batteryMenu._inhibit) {


### PR DESCRIPTION
Added modifications to remember the presentation mode state after reboot. Useful for computers that should be in presentation mode permanently.
